### PR TITLE
typo in delete model

### DIFF
--- a/db/config.js
+++ b/db/config.js
@@ -1,5 +1,5 @@
 const pgp = require('pg-promise')({}),
-config = process.env.DATABASE_URL || 'postgres://rebekahsunmibae@localhost:5432/woke_db',
+config = process.env.DATABASE_URL || 'postgres://jonathanellsaesser@localhost:5432/woke_db',
 db = pgp(config);
 
 module.exports = db;

--- a/models/news.js
+++ b/models/news.js
@@ -168,8 +168,8 @@ News.create = (req, res, next) => {
 }
 
 News.destroy = (req, res, next) => {
-    console.log("Firing delete");
-    const { id } = req.params.id;
+    console.log("Firing delete", req.params.id);
+    const id = req.params.id;
     db.none(
             'DELETE FROM news WHERE id = $1', [id]
         ).then(() => next())


### PR DESCRIPTION
Delete is working now.  We just had a typo in the delete model.  Everything was connected and firing properly, but we had `const { id } = req.params.id;` where we needed `const id = req.params.id;`

That object wrapper was the only issue.  I'm going to head over to the front end and look at the graphs.